### PR TITLE
fix: PushNotification without e-mail send

### DIFF
--- a/app/Http/Controllers/API/ItemController.php
+++ b/app/Http/Controllers/API/ItemController.php
@@ -175,6 +175,15 @@ class ItemController extends Controller
         if($item->type==Item::TYPE_SERVICE && $item->user_id != $request->user_id){
             $user = User::find($item->user_id);
 
+            try{
+                //Envio de push notification
+                $request_user = User::find($comment->user_id);
+                $request_user = ucwords(strtolower($request_user->name));
+                $user->notify(new PushNotification("Novo comentário em ".$item->title, $request_user.":\n\"".trim($comment->description)."\""));
+            } catch (\Throwable $th) {
+                //throw $th;
+            }
+
             try {
                 //Envio de Email
                 $email = new stdClass();
@@ -182,12 +191,6 @@ class ItemController extends Controller
                 $email->subject = 'Novo comentário na solicitação';
                 $mail = new Email($user,$email,$item);
                 $mail->build();
-
-                //Envio de push notification
-                $request_user = User::find($comment->user_id);
-                $request_user = ucwords(strtolower($request_user->name));
-                $user->notify(new PushNotification("Novo comentário em ".$item->title, $request_user.":\n\"".trim($comment->description)."\""));
-
             } catch (\Throwable $th) {
                 //throw $th;
             }


### PR DESCRIPTION
O erro no envio do E-mail de notificação quando houvesse algum comentário ou alteração no serviço estava impedindo que a Push Notification fosse enviada. Os dois estavam no mesmo Try Catch e quando dava o erro no envio do e-mail, ele acabava pulando pro catch e não realizava o envio da notificação.

Nessa issue, apenas separei as notificações de e-mail e do app em dois try/catchs para resolver esse problema e criei um try/catch para a solicitação de um novo serviço pois estava dando erro na solicitação justamente por causa do erro do e-mail.

Fix: #353 