### PR TITLE
feat: permite criar perguntas não obrigatórias

### DIFF
--- a/app/Http/Livewire/Order/Create.php
+++ b/app/Http/Livewire/Order/Create.php
@@ -65,8 +65,10 @@ class Create extends \App\Http\Livewire\Crud\Main
             $modelCrudInfo['fields'][$key] = $poll['fields'][$index];
             $modelCrudInfo['fields'][$key]['label'] = $field['text'] ?? '';
             
-            // Qualquer campo adicional é obrigatório
-            $modelCrudInfo['fields'][$key]['validation'] = 'required';
+            // Transforma o campo adicional em required se ele for obrigatório
+            if ((isset($field['data']['required']) && $field['data']['required'] != 'false') || !isset($field['data']['required'])) {
+                $modelCrudInfo['fields'][$key]['validation'] = 'required';
+            }
 
             // Se o campo customizado possuir alguma marcação de tipo, usamos ela
             // como o tipo do campo do formulário a ser gerado.
@@ -127,11 +129,13 @@ class Create extends \App\Http\Livewire\Crud\Main
         // Se chegamos aqui, é porque temos campos extra para esse pedido.
         // Vamos pegar o valor de cada um deles e colocar dentro do proprio
         // questionario usado para renderizar os campos extra.
+        // Quando o campo for uma pergunta não obrigatória não preenchida
+        // É atribuído um valor padrão para a resposta.
         $poll = $this->service->poll;
 
         foreach($poll['fields'] as $index => $field) {
             $key = 'poll_' . $index;
-            $poll['fields'][$index]['answer'] = $ajustedValues[$key];
+            $poll['fields'][$index]['answer'] = $ajustedValues[$key] ?? 'Pergunta não respondida pelo solicitante';
         }
 
         $ajustedValues['data'] = $poll;


### PR DESCRIPTION
Adicionei a possibilidade de criar perguntas adicionais não obrigatórias. Para não gerar problema com as questões já criadas anteriormente quando não for especificado se a pergunta é obrigatória ela é marcada como obrigatória por padrão.

Para marcar uma pergunta como não obrigatória basta usar a sintaxe `{"required": "false" }` antes da pergunta:
```
{"required": "false"} Sua pergunta aqui
{"type": "file", "required": "false"} Adicione o arquivo aqui
```
Quando uma pergunta não obrigatoria não é respondida eu anexei a mensagem "Pergunta não respondida pelo solicitante" como resposta para não gerar problema nas páginas que exibem as solicitações.

Também removi o css que não permitia copiar links das labels das perguntas e corrigi um problema que fazia não ser possível ler a resposta completa do solicitante caso ela fosse extensa:

![image](https://user-images.githubusercontent.com/51202548/153429837-f2e5fc84-6a07-4f8a-8482-afdc19a55975.png)

Agora respostas extensas são exibidas assim:

![image](https://user-images.githubusercontent.com/51202548/153429948-bc85c7e0-a4b3-4c08-8aa4-7853b1c84180.png)


Fix: #421 