### PR TITLE
feat: adiciona push notifications pela API central

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,5 @@ GITHUB_USER_UID_COMMENTS=
 GOOGLE_DRIVE_TASKS_FOLDER_ID=
 
 APP_EULA_URL="https://drive.google.com/file/d/1XYCLF2nCuWcnc8mBndMwESb4LjeO5uBh/view?usp=sharing"
+
+API_URL=http://localhost:8000/

--- a/app/Broadcasting/PushNotificationChannel.php
+++ b/app/Broadcasting/PushNotificationChannel.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\User;
+use GuzzleHttp\Client; 
+use Carbon\Carbon;
+use Firebase\JWT\JWT;
+
+class PushNotificationChannel
+{
+    /**
+     * Create a new channel instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    public function send($notifiable, $notification)
+    {
+        $data = $notification->toPushNotification($notifiable);
+
+        $key = env('APP_KEY');
+        $payload = array(
+            'iss' => env('APP_NAME'),
+            'aud' => 'practice.uffs.edu.br',
+            'iat' => Carbon::now()->timestamp,
+            'nbf' => Carbon::now()->timestamp - 1,
+            'app_id' => env('APP_ID'),
+            'user' => $notifiable
+        );
+        $jwt = JWT::encode($payload, $key);
+
+        $client = new Client();     
+        $client->get('http://127.0.0.1:8000/v0/user/notify/push', [
+            'headers' => [ 'Authorization' => 'Bearer ' . $jwt ],
+            'json' => $data
+        ]);
+    }
+
+    /**
+     * Authenticate the user's access to the channel.
+     *
+     * @param  \App\Models\User  $user
+     * @return array|bool
+     */
+    public function join(User $user)
+    {
+        //
+    }
+}

--- a/app/Broadcasting/PushNotificationChannel.php
+++ b/app/Broadcasting/PushNotificationChannel.php
@@ -33,9 +33,10 @@ class PushNotificationChannel
             'user' => $notifiable
         );
         $jwt = JWT::encode($payload, $key);
+        $apiUrl = env('API_URL').'v0/user/notify/push';
 
         $client = new Client();     
-        $client->get('http://127.0.0.1:8000/v0/user/notify/push', [
+        $client->get($apiUrl, [
             'headers' => [ 'Authorization' => 'Bearer ' . $jwt ],
             'json' => $data
         ]);

--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -47,8 +47,6 @@ class Comments extends Component
             'content' => $this->content
         ]);
 
-        OrderCommented::dispatch($this->commentable, $comment);
-        
         $this->resetInput();
     }
 

--- a/app/Notifications/OrderCommented.php
+++ b/app/Notifications/OrderCommented.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use App\Broadcasting\PushNotificationChannel;
 
 class OrderCommented extends Notification implements ShouldQueue
 {
@@ -35,7 +36,15 @@ class OrderCommented extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return [PushNotificationChannel::class, 'mail'];
+    }
+
+    public function toPushNotification($notifiable)
+    {
+        return [
+            'title' => "Nova movimentação (Practice Mural #" . $this->order->id . ")",
+            'body' => "Sua solicitação '" . $this->order->title . "' recebeu um novo comentário",
+        ];
     }
 
     /**

--- a/app/Notifications/OrderCommented.php
+++ b/app/Notifications/OrderCommented.php
@@ -36,7 +36,7 @@ class OrderCommented extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return [PushNotificationChannel::class, 'mail'];
+        return ['mail', PushNotificationChannel::class];
     }
 
     public function toPushNotification($notifiable)

--- a/app/Notifications/OrderCompleted.php
+++ b/app/Notifications/OrderCompleted.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use App\Broadcasting\PushNotificationChannel;
 
 class OrderCompleted extends Notification implements ShouldQueue
 {
@@ -35,7 +36,7 @@ class OrderCompleted extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['mail', PushNotificationChannel::class];
     }
 
     /**
@@ -58,6 +59,14 @@ class OrderCompleted extends Notification implements ShouldQueue
                     ->line('Sua avaliação é muito importante! Ela ajuda a melhorar nossos serviços.')
                     ->line("Até mais,")
                     ->salutation("Equipe Practice ❤️");
+    }
+
+    public function toPushNotification($notifiable)
+    {
+        return [
+            'title' => "Solicitação concluída (Practice Mural #" . $this->order->id . ")",
+            'body' => "Sua solicitação '" . $this->order->title . "' foi concluída",
+        ];
     }
 
     /**

--- a/app/Notifications/OrderCreated.php
+++ b/app/Notifications/OrderCreated.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use App\Broadcasting\PushNotificationChannel;
 
 class OrderCreated extends Notification implements ShouldQueue
 {
@@ -33,7 +34,7 @@ class OrderCreated extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['mail', PushNotificationChannel::class];
     }
 
     /**
@@ -53,6 +54,14 @@ class OrderCreated extends Notification implements ShouldQueue
                     ->line('Avisaremos sobre o andamento do seu pedido.')
                     ->line("Até mais,")
                     ->salutation("Equipe Practice ❤️");
+    }
+
+    public function toPushNotification($notifiable)
+    {
+        return [
+            'title' => "Solicitação recebida (Practice Mural #" . $this->order->id . ")",
+            'body' => "A Equipe Practice recebeu sua solicitação '".$this->order->title."' Faremos a análise de viabilidade do seu pedido em seguida.",
+        ];
     }
 
     /**

--- a/app/Notifications/OrderNeedsReview.php
+++ b/app/Notifications/OrderNeedsReview.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use App\Broadcasting\PushNotificationChannel;
 
 class OrderNeedsReview extends Notification implements ShouldQueue
 {
@@ -33,7 +34,7 @@ class OrderNeedsReview extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['mail', PushNotificationChannel::class];
     }
 
     /**
@@ -52,6 +53,14 @@ class OrderNeedsReview extends Notification implements ShouldQueue
                     ->line('Você tem no máximo 72h para revisar, depois disso seguiremos nosso trabalho. Não deixe para revisar depois 😉! Sua interação garante que possamos finalizar sua solicitação, seguindo suas dicas, o mais rápido possível.')
                     ->line("Até mais,")
                     ->salutation("Equipe Practice ❤️");
+    }
+
+    public function toPushNotification($notifiable)
+    {
+        return [
+            'title' => "Precisamos da sua revisão (Practice Mural #" . $this->order->id . ")",
+            'body' => "Temos materiais prontos referentes à solicitação '".$this->order->title."'. Precisamos da sua revisão.",
+        ];
     }
 
     /**

--- a/app/Notifications/OrderStarted.php
+++ b/app/Notifications/OrderStarted.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use App\Broadcasting\PushNotificationChannel;
 
 class OrderStarted extends Notification implements ShouldQueue
 {
@@ -33,7 +34,7 @@ class OrderStarted extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['mail', PushNotificationChannel::class];
     }
 
     /**
@@ -53,6 +54,14 @@ class OrderStarted extends Notification implements ShouldQueue
                     ->line('Avisaremos sobre o andamento do seu pedido.')
                     ->line("Até mais,")
                     ->salutation("Equipe Practice ❤️");
+    }
+
+    public function toPushNotification($notifiable)
+    {
+        return [
+            'title' => "Sua solicitação foi iniciada! (Practice Mural #" . $this->order->id . ")",
+            'body' => "A Equipe Practice começou a trabalhar na sua solicitação '".$this->order->title."'",
+        ];
     }
 
     /**


### PR DESCRIPTION
Utilizei a mesma estrutura que é usada para o envio de email, então agora além de enviar o email também será enviada uma push notification caso a pessoa tenha o aplicativo instalado. Tentei manter as mensagens enviadas parecidas com as do email, mas é possível alterar o conteúdo da notificação facilmente. Também notei que ao comentar o evento de notificação estava sendo disparado duas vezes, então corrigi isso também.

Como eu precisava do jwt token para acessar a rota da api eu gerei um token compatível para o usuário que vai receber a notificação na função que vai disparar o envio da mesma e utilizei ele para fazer a request para a api. 

Fix: #374 


