### PR TITLE
fix: corrige os problemas do layout da tela de acompanhamento de pedidos

### DIFF
--- a/resources/views/order/list.blade.php
+++ b/resources/views/order/list.blade.php
@@ -23,22 +23,22 @@
 
         <div class="row">
             <div class="col-12">
-                <table class="table w-full">
-                    <thead>
-                        <tr>
-                            <th>Tipo</th>
-                            <th>Título</th>
-                            <th>Situação</th>
-                            <th>Data</th>
+                <table class="d-flex flex-column">
+                    <thead class="d-flex flex-row w-auto">
+                        <tr class="row w-100">
+                            <th class="order-2 order-lg-1 col-12 col-lg-2 col-md-4">Tipo</th>
+                            <th class="order-3 order-lg-2 col-12 col-lg-4 col-md-8">Título</th>
+                            <th class="order-1 order-lg-3 col-12 col-lg-2">Situação</th>
+                            <th class="order-4 order-md-4 col-6 col-lg-3 col-md-8">Data</th>
                             <th></th>
                         </tr>
                     </thead>                
-                    <tbody>
+                    <tbody class="d-flex flex-column">
                         @foreach ($orders as $order)
-                            <tr>
-                                <td>
-                                    <div class="flex items-center space-x-3">
-                                        <div class="avatar">
+                            <tr class="row py-3 border-bottom">
+                                <td class="order-2 order-lg-1 col-12 col-lg-2 col-md-4">
+                                    <div class="d-flex flex-sm-column">
+                                        <div class="avatar pr-3">
                                             <div class="w-10 h-10 mask mask-circle bg-{{ @$order->service->category->color }}">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 mx-auto mt-1 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                                     {!! @$order->service->icon_svg_path !!}
@@ -51,19 +51,19 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td>
+                                <td class="order-3 order-lg-2 pb-3 col-12 col-lg-4 col-md-8 text-wrap d-md-flex align-items-md-end align-items-lg-center ">
                                     {{ $order->title }}
                                 </td>
-                                <td>
+                                <td class="order-1 order-lg-3 col-12 col-lg-2 d-flex justify-content-end justify-content-lg-start pb-1 pl-0 align-items-center">
                                     <span class="badge badge-outline badge-info badge-md">{{ $order->situation()->text }}</span>
                                 </td>
-                                <td>
+                                <td class="order-4 order-md-4 col-6 col-lg-3 col-md-8 pt-2  d-lg-flex align-items-lg-start justify-content-lg-center flex-lg-column">
                                     <div>{{ $order->created_at }}</div>
                                     <div class="text-sm opacity-50">Última atualização: {{ $order->updated_at }}</div>
                                 </td>
-                                <th>
-                                    <a href="{{ route('order.show', [$order->id]) }}" class="btn btn-primary">Ver detalhes</a>
-                                </th>
+                                <td class="order-5 order-md-5 col-6 col-lg-1 col-md-4 pt-2 d-flex justify-content-end justify-content-lg-start align-items-end  align-items-lg-start d-lg-flex align-items-lg-center">
+                                    <a href="{{ route('order.show', [$order->id]) }}" class="btn btn-primary">Detalhes</a>
+                                </td>
                             </tr>
                         @endforeach
                     </tbody>

--- a/resources/views/order/list.blade.php
+++ b/resources/views/order/list.blade.php
@@ -24,7 +24,7 @@
         <div class="row">
             <div class="col-12">
                 <table class="d-flex flex-column">
-                    <thead class="d-flex flex-row w-auto">
+                    <thead class="d-lg-flex flex-row w-auto d-none">
                         <tr class="row w-100">
                             <th class="order-2 order-lg-1 col-12 col-lg-2 col-md-4">Tipo</th>
                             <th class="order-3 order-lg-2 col-12 col-lg-4 col-md-8">Título</th>
@@ -38,7 +38,7 @@
                             <tr class="row py-3 border-bottom">
                                 <td class="order-2 order-lg-1 col-12 col-lg-2 col-md-4">
                                     <div class="d-flex flex-sm-column">
-                                        <div class="avatar pr-3">
+                                        <div class="avatar pr-3 pb-2">
                                             <div class="w-10 h-10 mask mask-circle bg-{{ @$order->service->category->color }}">
                                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 mx-auto mt-1 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                                     {!! @$order->service->icon_svg_path !!}


### PR DESCRIPTION
A tela de acompanhamento de pedidos era bem pouco responsiva e apresentava dificuldades de uso em vários os tamanhos, então eu ajustei o layout para um conjunto maior de tamanhos.

**Mobile:**
![image](https://user-images.githubusercontent.com/51202548/159014520-c40cfe2a-84bf-41d5-900f-4b98b6a5bdd3.png)

**Tamanho médio:**
![image](https://user-images.githubusercontent.com/51202548/159014859-7b49d20d-0b23-4b0c-a48c-90162799ff23.png)

**Desktop:**
![image](https://user-images.githubusercontent.com/51202548/159014977-fd215c68-deb4-4ef7-94f0-dcabc77e61b9.png)

Fix: #440 