### PR TITLE
feat: adicionado quebra de linha nos comentários #401

### DIFF
--- a/resources/views/livewire/comments/main.blade.php
+++ b/resources/views/livewire/comments/main.blade.php
@@ -32,7 +32,7 @@
                                 <i class="bi bi-clock"></i> {{ $comment['created_at_human'] }}
                             </span>
                         </div>
-                        <div class="text-md pt-2">{!! Str::markdown($comment['content']) !!}</div>
+                        <div class="text-md pt-2">{!! nl2br(Str::markdown($comment['content'])) !!}</div>
                         <div class="mt-4 flex items-center hidden">
                             <div class="flex -space-x-2 mr-2">
                                 <img class="rounded-full w-6 h-6 border border-white"


### PR DESCRIPTION
Fix: #401 

Conforme tarefa antiga.
Verifiquei que as tags para markdown estavam funcionando.
Porém, a quebra de linha não estava refletindo nos comentários.
Adicionei o nl2br na hora de listar os comentários. Essa função identifica e mostra as quebras de linha.