### PR TITLE
feat: cria tratamento para adição de labels relacionadas ao status do pedido no mural

### DIFF
--- a/app/Services/Github.php
+++ b/app/Services/Github.php
@@ -18,9 +18,9 @@ class Github
 
     /**
      * Returns an instance of `Github\Client`.
-     * 
+     *
      * @param bool $authenticated if the instance should be authenticated or not.
-     * 
+     *
      * @return Client instance of github client ready for use.
      */
     public function getClient($authenticated = false): Client
@@ -28,7 +28,7 @@ class Github
         $guzz_client = new \GuzzleHttp\Client([
             \GuzzleHttp\RequestOptions::VERIFY => \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath()
         ]);
-        
+
         $gh = Client::createWithHttpClient($guzz_client);
 
         if($authenticated) {
@@ -37,18 +37,28 @@ class Github
 
             $gh->authenticate($token, null, Client::AUTH_ACCESS_TOKEN);
         }
-        
+
         return $gh;
     }
 
     /**
      * @param string $content
-     * 
+     *
      * @return [type]
      */
     public function commentIssue($org, $repo, $issueNumber, string $content)
     {
         $this->client->api('issue')->comments()->create($org, $repo, $issueNumber, array('body' => $content));
+    }
+
+    public function removeLabel($org, $repo, $issueNumber, string $labelName)
+    {
+        $this->client->api('issue')->labels()->remove($org, $repo, $issueNumber, $labelName);
+    }
+
+    public function getLabels($org, $repo, $issueNumber)
+    {
+        return $this->client->api('issue')->labels()->all($org, $repo, $issueNumber);
     }
 
     /**
@@ -89,7 +99,7 @@ class Github
         }
 
         return $json;
-    }    
+    }
 
     /**
      * Process a webhook request sent by Github servers.
@@ -101,10 +111,10 @@ class Github
     public function processWebhookRequest(Request $request): array
     {
         $secret = config('github.webhook_secret');
-        
+
         $this->assertValidGithubWebhook($secret, $request);
 
-        $event = $request->headers->get('X-GitHub-Event');        
+        $event = $request->headers->get('X-GitHub-Event');
         $payload = $this->readPayloadAsJson($request);
 
         return [


### PR DESCRIPTION
Pra conseguir testar, precisa disponibilizar o servidor (localhost) na internet, pois o webhooks do github fará requisições.

Também é necessário ajustar as configurações de wehook do playground para o link de host que foi criado.

Podemos testar a funcionalidade aqui: https://2071-2804-f40-309-9b01-88f0-98ee-23c9-576e.sa.ngrok.io (deixarei rodando por um tempo)

A ideia é usar as tags `mural:<alguma_coisa>` pra alterar os estados diretamente no mural. Ao adicionar uma tag desse tipo, as demais desse tipo são removidas e o mural é atualizado com a tag selecionada.

Como ele altera apenas no banco de dados, é necessário dar `f5` no mural.

Fix: #470 