### PR TITLE
feat: set github label when change the order status 

### DIFF
--- a/app/Http/Controllers/API/GithubWebhookController.php
+++ b/app/Http/Controllers/API/GithubWebhookController.php
@@ -235,10 +235,24 @@ class GithubWebhookController extends Controller
         return response('Issue opened and commented: ' . $comment, 200);
     }
 
+    public function setMuralLabel($org, $repo, $issue, $label)
+    {
+        $mural_labels = ['mural:fila', 'mural:andamento', 'mural:revisão', 'mural:completo', 'mural:cancelado'];
+        $active_labels = $this->github->getLabels($org, $repo, $issue);
+
+        foreach ($active_labels as $active_label) {
+            if (in_array($active_label['name'], $mural_labels) and strcmp($active_label['name'], $label) != 0) {
+                $this->github->removeLabel($org, $repo, $issue, $active_label['name']);
+            }
+        }
+
+        $this->github->removeLabel($org, $repo, $issue, $label);
+    }
+
     protected function handleIssueLabeled(array $payload, $org, $repo, $issue)
     {
         $label = $payload['label'];
-        $url = "https://github.com/".substr($payload['issue']['url'], strrpos($payload['issue']['url'], "practice-uffs"));
+        $url = "https://github.com/".substr($payload['issue']['url'], strpos($payload['issue']['url'], "practice-uffs"));
         $order = Order::where('github_issue_link', $url)->first();
 
         if($order) {

--- a/app/Http/Controllers/API/GithubWebhookController.php
+++ b/app/Http/Controllers/API/GithubWebhookController.php
@@ -235,7 +235,7 @@ class GithubWebhookController extends Controller
         return response('Issue opened and commented: ' . $comment, 200);
     }
 
-    public function setMuralLabel($org, $repo, $issue, $label)
+    public function setMuralLabel($org, $repo, $issue, $label = NULL)
     {
         $mural_labels = ['mural:fila', 'mural:andamento', 'mural:revisão', 'mural:completo', 'mural:cancelado'];
         $active_labels = $this->github->getLabels($org, $repo, $issue);
@@ -245,8 +245,9 @@ class GithubWebhookController extends Controller
                 $this->github->removeLabel($org, $repo, $issue, $active_label['name']);
             }
         }
-
-        $this->github->removeLabel($org, $repo, $issue, $label);
+        if($label) {
+            $this->github->addLabel($org, $repo, $issue, $label);
+        }
     }
 
     protected function handleIssueLabeled(array $payload, $org, $repo, $issue)

--- a/app/Http/Livewire/Order/Show.php
+++ b/app/Http/Livewire/Order/Show.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 use App\Http\Controllers\API\GithubWebhookController;
+use App\Services\Github;
+use App\Services\GoogleDrive;
 
 class Show extends Component
 {
@@ -55,25 +57,28 @@ class Show extends Component
         $repo = $array[2];
         $issue = $array[4];
 
+        $gwc = new GithubWebhookController(new Github(config('github')), new GoogleDrive(config('google.drive')));
         switch($this->status)
         {
+            case NULL:
+                $gwc->setMuralLabel($org, $repo, $issue);
+                break;
             case 'todo':
-                GithubWebhookController::class;
+                $gwc->setMuralLabel($org, $repo, $issue, 'mural:fila');
                 break;
             case 'doing':
-
+                $gwc->setMuralLabel($org, $repo, $issue, 'mural:andamento');
                 break;
             case 'review':
-
+                $gwc->setMuralLabel($org, $repo, $issue, 'mural:revisão');
                 break;
             case 'completed':
-
+                $gwc->setMuralLabel($org, $repo, $issue, 'mural:completo');
                 break;
             case 'closed':
-
+                $gwc->setMuralLabel($org, $repo, $issue, 'mural:cancelado');
                 break;
             default:
-
         }
     }
 

--- a/app/Http/Livewire/Order/Show.php
+++ b/app/Http/Livewire/Order/Show.php
@@ -6,6 +6,7 @@ use App\Jobs\ProcessGoogleDriveUploads;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Livewire\WithFileUploads;
+use App\Http\Controllers\API\GithubWebhookController;
 
 class Show extends Component
 {
@@ -41,7 +42,39 @@ class Show extends Component
             'status' => $this->status,
         ]);
 
+        $this->changeGithubLabel();
+
         $this->emit('order:statusChanged');
+    }
+
+    public function changeGithubLabel()
+    {
+        $tail = substr($this->github_issue_link, strpos($this->github_issue_link, 'github.com/'));
+        $array = preg_split("/[\/]/",$tail);
+        $org = $array[1];
+        $repo = $array[2];
+        $issue = $array[4];
+
+        switch($this->status)
+        {
+            case 'todo':
+                GithubWebhookController::class;
+                break;
+            case 'doing':
+
+                break;
+            case 'review':
+
+                break;
+            case 'completed':
+
+                break;
+            case 'closed':
+
+                break;
+            default:
+
+        }
     }
 
     public function saveFiles() {

--- a/app/Services/Github.php
+++ b/app/Services/Github.php
@@ -56,6 +56,11 @@ class Github
         $this->client->api('issue')->labels()->remove($org, $repo, $issueNumber, $labelName);
     }
 
+    public function addLabel($org, $repo, $issueNumber, string $labelName)
+    {
+        $this->client->api('issue')->labels()->add($org, $repo, $issueNumber, $labelName);
+    }
+
     public function getLabels($org, $repo, $issueNumber)
     {
         return $this->client->api('issue')->labels()->all($org, $repo, $issueNumber);

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,12 +27,12 @@ Route::group(['as' => 'api.', 'middleware' => 'jwt.practice'], function() {
     Orion::resource('services', 'API\ServiceController');
     Orion::resource('comments', 'API\CommentController');
 
-    Route::get('/me', function() { 
+    Route::get('/me', function() {
         return response()->json(['user' => Auth::user()]);
     });
 
     if (App::environment('local')) {
-        Route::get('/ping', function() { 
+        Route::get('/ping', function() {
             return response()->json(['pong' => Auth::user()]);
         });
     }


### PR DESCRIPTION
Nesta issue, adicionei a função de alterar label quando se altera o status de um pedido no mural.

Acredito que a implementação não é a ideal, tentei entender como funciona o controller do `GithubWebhookController`, mas não consegui. Acabei criando uma nova instância dessa classe para utilizar o método.

Fix: #485 