### PR TITLE
fix: Erro quando link do git é nulo

### DIFF
--- a/app/Http/Livewire/Order/Show.php
+++ b/app/Http/Livewire/Order/Show.php
@@ -44,7 +44,9 @@ class Show extends Component
             'status' => $this->status,
         ]);
 
-        $this->changeGithubLabel();
+        if ($this->github_issue_link){
+            $this->changeGithubLabel();
+        }
 
         $this->emit('order:statusChanged');
     }


### PR DESCRIPTION
Apenas fiz uma verificação antes do método para checar se o link do git está nulo ou não.

Fix: #489 