### PR TITLE
feat: Adiciona fluxo de pastas ao adicionar link no pedido 

### DIFF
--- a/app/Http/Controllers/API/GithubWebhookController.php
+++ b/app/Http/Controllers/API/GithubWebhookController.php
@@ -247,21 +247,6 @@ class GithubWebhookController extends Controller
         return response('Issue opened and commented: ' . $comment, 200);
     }
 
-    public function setMuralLabel($org, $repo, $issue, $label = NULL)
-    {
-        $mural_labels = ['mural:fila', 'mural:andamento', 'mural:revisão', 'mural:completo', 'mural:cancelado'];
-        $active_labels = $this->github->getLabels($org, $repo, $issue);
-
-        foreach ($active_labels as $active_label) {
-            if (in_array($active_label['name'], $mural_labels) and strcmp($active_label['name'], $label) != 0) {
-                $this->github->removeLabel($org, $repo, $issue, $active_label['name']);
-            }
-        }
-        if($label) {
-            $this->github->addLabel($org, $repo, $issue, $label);
-        }
-    }
-
     protected function handleIssueLabeled(array $payload, $org, $repo, $issue)
     {
         $label = $payload['label'];

--- a/app/Http/Livewire/Order/Show.php
+++ b/app/Http/Livewire/Order/Show.php
@@ -6,9 +6,7 @@ use App\Jobs\ProcessGoogleDriveUploads;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Livewire\WithFileUploads;
-use App\Http\Controllers\API\GithubWebhookController;
 use App\Services\Github;
-use App\Services\GoogleDrive;
 
 class Show extends Component
 {
@@ -37,6 +35,7 @@ class Show extends Component
 
     public function save()
     {
+        $previousGithubIssueLink = substr($this->order->github_issue_link,0, strlen($this->github_issue_link));
         $this->validate();
 
         $this->order->update([
@@ -44,8 +43,12 @@ class Show extends Component
             'status' => $this->status,
         ]);
 
+
         if ($this->github_issue_link){
             $this->changeGithubLabel();
+            if(!$previousGithubIssueLink){
+                $this->createGDriveFolderComment();
+            }
         }
 
         $this->emit('order:statusChanged');
@@ -83,6 +86,19 @@ class Show extends Component
                 break;
             default:
         }
+    }
+
+    public function createGDriveFolderComment()
+    {
+        $tail = substr($this->github_issue_link, strpos($this->github_issue_link, 'github.com/'));
+        $array = preg_split("/[\/]/", $tail);
+        $org = $array[1];
+        $repo = $array[2];
+        $issue = $array[4];
+        $content = "mural: ".env('APP_URL')."servico/".$this->order->id;
+
+        $gwc = app()->make(Github::class);
+        $gwc->commentIssue($org, $repo, $issue, $content);
     }
 
     public function saveFiles() {

--- a/app/Http/Livewire/Order/Show.php
+++ b/app/Http/Livewire/Order/Show.php
@@ -59,7 +59,8 @@ class Show extends Component
         $repo = $array[2];
         $issue = $array[4];
 
-        $gwc = new GithubWebhookController(new Github(config('github')), new GoogleDrive(config('google.drive')));
+        $gwc = app()->make(Github::class);
+
         switch($this->status)
         {
             case NULL:

--- a/app/Services/Github.php
+++ b/app/Services/Github.php
@@ -127,4 +127,19 @@ class Github
             'payload' => $payload
         ];
     }
+
+    public function setMuralLabel($org, $repo, $issue, $label = NULL)
+    {
+        $mural_labels = ['mural:fila', 'mural:andamento', 'mural:revisão', 'mural:completo', 'mural:cancelado'];
+        $active_labels = $this->getLabels($org, $repo, $issue);
+
+        foreach ($active_labels as $active_label) {
+            if (in_array($active_label['name'], $mural_labels) and strcmp($active_label['name'], $label) != 0) {
+                $this->removeLabel($org, $repo, $issue, $active_label['name']);
+            }
+        }
+        if ($label) {
+            $this->addLabel($org, $repo, $issue, $label);
+        }
+    }
 }


### PR DESCRIPTION
Nesta issue, foi adicionado uma feature quando você linka uma issue com o pedido. No mural, quando você adicionar o link da issue, o bot irá adicionar a mensagem de vínculo de pastas do Google drive.

![Peek 2022-06-21 10-59](https://user-images.githubusercontent.com/51202705/174818533-2b9c9fb3-1f04-48cc-838a-b59bb52aa1bd.gif)


Fix: #495 