### PR TITLE
537

### DIFF
--- a/app/Http/Controllers/Admin/FeedbacksController.php
+++ b/app/Http/Controllers/Admin/FeedbacksController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+
+class FeedbacksController extends Controller
+{
+    /**
+     * Show the dashboard of feedbacks.
+     *
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function index()
+    {
+        return view('admin.feedbacks');
+    }
+
+    public function show(int $id)
+    {
+        return view('feedback.show', 
+            ['id' => $id]
+        );
+    }    
+}

--- a/app/Http/Livewire/Admin/Feedbacks.php
+++ b/app/Http/Livewire/Admin/Feedbacks.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Livewire\Admin;
+
+use App\Models\Feedback;
+use Livewire\Component;
+use Carbon\Carbon;
+
+
+class Feedbacks extends Component
+{
+    protected $feedbacks;
+    public int $paginationAmount = 50;
+
+    public function mount()
+    {
+        $this->findFeedbacks();
+    }
+
+
+    public function findFeedbacks()
+    {
+        $query = Feedback::with('user');
+
+        $query->orderBy('created_at', 'desc');
+
+        $this->feedbacks = $query->paginate($this->paginationAmount);
+    }
+
+
+    public function render()
+    {
+        return view('livewire.admin.feedbacks', [
+            'feedbacks' => $this->feedbacks
+        ]);
+    }
+}

--- a/app/Http/Livewire/Feedback/Show.php
+++ b/app/Http/Livewire/Feedback/Show.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Livewire\Feedback;
+
+use App\Models\Feedback;
+use Livewire\Component;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+
+class Show extends Component
+{
+
+    public Collection $feedback;
+    public int $idFeedback;
+
+    public function mount(){
+        $this->findFeedback();
+    }
+
+    public function findFeedback(){
+        $this->feedback = Feedback::with('user')->where('id',$this->idFeedback)->get();
+    }
+
+    public function render()
+    {
+        return view('livewire.feedback.show',[
+            'feedback' => $this->feedback
+    ]);
+    }
+}

--- a/app/Models/Feedback.php
+++ b/app/Models/Feedback.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
+
 
 class Feedback extends Model
 {
@@ -91,4 +93,18 @@ class Feedback extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+
+    public function getCreatedAtHumanAttribute()
+    {
+
+        $diffInDays = $this->created_at->diffInDays(Carbon::now());
+
+        if ($diffInDays > 3) {
+            return $this->created_at->format('d/m/Y (h:i)');
+        }
+
+        return $this->created_at->diffForHumans();
+    }
+
 }

--- a/resources/views/admin/feedbacks.blade.php
+++ b/resources/views/admin/feedbacks.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.base')
+@section('content')
+<section>
+    <div class="container mt-10">
+        <header class="section-header mt-10">
+            <h2>Feedbacks de usuários</h2>
+            <p>Visualização de feedbacks</p>
+        </header>
+        @livewire('admin.feedbacks')
+    </div>
+</section>
+@endsection

--- a/resources/views/feedback/show.blade.php
+++ b/resources/views/feedback/show.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.base')
+@section('content')
+<section>
+    <div class="container">
+        <header class="section-header">
+            <h2>Feedbacks</h2>
+            <p>Informações de feedbacks</p>
+        </header>
+        <div class="row items-center">
+            <div class="col-lg-12 col-md-12"> 
+                <!-- passa o id para realizar a consulta -->
+                @livewire('feedback.show',['idFeedback'=>$id])
+            </div>
+        </div>
+    </div>
+</section>
+@endsection

--- a/resources/views/layouts/header.blade.php
+++ b/resources/views/layouts/header.blade.php
@@ -18,6 +18,9 @@
                             <li class="dropdown-item"><a class="nav-link"
                                     href="{{ route('admin.orders') }}">Pedidos</a></li>
                             <li class="dropdown-item">
+                            <li class="dropdown-item"><a class="nav-link"
+                                    href="{{ route('admin.feedbacks') }}">Feedbacks</a></li>
+                            <li class="dropdown-item">
                                 <hr />
                             </li>
                             <li class="dropdown-item"><a class="nav-link"

--- a/resources/views/livewire/admin/feedbacks.blade.php
+++ b/resources/views/livewire/admin/feedbacks.blade.php
@@ -1,0 +1,92 @@
+<!-- list of elements -->
+<div class="row mt-4">
+    <div class="col-12">{!! $feedbacks->links() !!}</div>
+</div>
+<div class="row col-12">
+    <div class="table-responsive">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Comentário</th>
+                    <th scope="col">
+                        <div class="text-center">Data</div>
+                    </th>
+                    <th scope="col">
+                        <div class="text-center">Criador</div>
+                    </th>
+                    <th scope="col">
+                        <div class="text-center">Tipo</div>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse ($feedbacks as $feedback)
+                    <tr>
+                        <td scope="row">
+                            <a href="{{ route('feedback.show', [$feedback['id']]) }}" class="btn btn-primary">Ver</a>
+                        </td>
+                        <td class="text-wrap">
+                            <div class="flex items-center space-x-3">
+                                <div>
+                                    <div class="font-bold">
+                                        @if(strlen($feedback['comment'])>50) 
+                                            {{substr($feedback['comment'],0,47).' ...'}}
+                                        @else
+                                            {{$feedback['comment']}}
+                                        @endif
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="w-max d-flex flex-column align-items-center">
+                                <div>
+                                    <svg xmlns="http://www.w3.org/2000/svg"
+                                        class="h-6 w-6 text-gray-300 float-left mr-2" fill="none"
+                                        viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                    </svg>
+                                    {{ $feedback['created_at_human'] }}
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="d-flex flex-column align-items-center">
+                                {!! Str::title(@$feedback['user']['name']) !!}
+                            </div>
+                        </td>
+                        <td>
+                            <div class="d-flex align-items-center justify-content-center">
+                                <span class="badge badge-outline badge-info badge-md"> 
+                                    @switch ($feedback['type']) 
+                                        @case('critic')
+                                            Crítica
+                                            @break;
+                                        @case("comment")
+                                            Comentário
+                                            @break;
+                                        @case("compliment")
+                                            Elogio
+                                            @break;
+                                        @case("suggestion")
+                                            Sugestão
+                                           @break;
+                                    @endswitch
+                                </span>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6">Nenhum feedback encontrado.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+<div class="row mt-4">
+    <div class="col-12">{!! $feedbacks->links() !!}</div>
+</div>

--- a/resources/views/livewire/admin/feedbacks.blade.php
+++ b/resources/views/livewire/admin/feedbacks.blade.php
@@ -29,6 +29,7 @@
                         <td class="text-wrap">
                             <div class="flex items-center space-x-3">
                                 <div>
+                                    <!--Defini um tamanho maximo de 50 chars-->
                                     <div class="font-bold">
                                         @if(strlen($feedback['comment'])>50) 
                                             {{substr($feedback['comment'],0,47).' ...'}}

--- a/resources/views/livewire/feedback/show.blade.php
+++ b/resources/views/livewire/feedback/show.blade.php
@@ -1,0 +1,37 @@
+<div>
+    <div class="flex items-center flex-wrap pb-3 mb-3 border-b-2 border-gray-100 mt-auto w-full">
+        <span class="text-gray-400 inline-flex items-center leading-none text-sm pr-3 py-1">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-1" fill="none" viewBox="0 0 24 24"
+                stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            Criado em {{ ($feedback[0]['created_at']->diffForHumans()) }}
+        </span>
+    </div>
+    <div>
+        <div class="text-gray-600 body-font overflow-hidden">
+            <div class="flex flex-center">
+                <div class="w-full flex flex-col items-center">
+                    <h3 class="sm:text-3xl text-2xl font-medium text-gray-900 mt-2 mb-4">{{$feedback[0]['comment']}}</h3>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div>
+        <div class="row">
+            <small class="small text-gray-900 m-2">Por:</small>
+        </div>
+        <div class="row">
+            <span class="inline-flex items-center">
+                <img alt="blog" src="https://cc.uffs.edu.br/avatar/iduffs/{{ $feedback[0]['user']['username'] }}"
+                    class="w-12 h-12 rounded-full flex-shrink-0 object-cover object-center">
+                <span class="flex-grow flex flex-col pl-4">
+                    <span class="title-font font-medium text-gray-900">{{ $feedback[0]['user']['name'] }}</span>
+                    <span
+                        class="text-gray-400 text-xs tracking-widest mt-0.5">{{ $feedback[0]['user']['username'] }}</span>
+                </span>
+            </span>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\LocationController;
 use App\Http\Controllers\Admin\ServiceController as AdminServiceController;
 use App\Http\Controllers\Admin\OrderController as AdminOrderController;
+use App\Http\Controllers\Admin\FeedbacksController as AdminFeedbacksController;
 use App\Http\Controllers\Admin\SubscriberController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Auth\LoginController;
@@ -71,6 +72,8 @@ Route::group(['middleware' => 'auth'], function () {
     // Admin
     Route::group(['middleware' => 'check.admin'], function () {
         Route::get('/gerenciar/pedidos', [AdminOrderController::class, 'index'])->name('admin.orders');
+        Route::get('/gerenciar/feedbacks', [AdminFeedbacksController::class, 'index'])->name('admin.feedbacks');    
+        Route::get('/gerenciar/feedbacks/{feedback}', [AdminFeedbacksController::class, 'show'])->name('feedback.show');
         Route::get('/gerenciar/servicos', [AdminServiceController::class, 'index'])->name('admin.service');
         Route::get('/gerenciar/lugares', [LocationController::class, 'index'])->name('admin.location');
         Route::get('/gerenciar/categorias', [CategoryController::class, 'index'])->name('admin.category');


### PR DESCRIPTION
# Criação das telas relacionadas a vizualização de feedbacks
## A nav bar ficou assim:
![Captura de tela de 2023-02-09 10-51-11](https://user-images.githubusercontent.com/85875309/217832517-4be5a58d-3472-4dc1-9652-8ff0e04e2047.png)
## Quando clicado entra no "main dos feedbacks":
![Captura de tela de 2023-02-09 10-51-39](https://user-images.githubusercontent.com/85875309/217832785-99469beb-c33d-4c09-ab06-1d7e2554eee9.png)
## que por sua vez é redirecionado para algum feedback em específico:
![Captura de tela de 2023-02-09 10-52-01](https://user-images.githubusercontent.com/85875309/217833231-a968e458-9b10-4c79-90db-956c8c957cfa.png)
No começo até pensei em fazer um modal simples, mas isso podia acarretar no seguinte problema: admin x quer mostrar para funcionário y, que o feedback numero 139 era legal, porem teria que enviar a pagina do main para o usuário y procurar dentre os vários existentes. OBS: isso aconteceria no pior caso (ter muitos feedbacks, o que não é ruim para o programa), alem disso os feedbacks são exibidos do mais recente para o mais antigo.
issue #537 .