### PR TITLE
feat: #547 filtro de pesquisa na página de pedidos

### DIFF
--- a/app/Http/Livewire/Admin/Orders.php
+++ b/app/Http/Livewire/Admin/Orders.php
@@ -106,6 +106,17 @@ class Orders extends Component
             'comments.user'
         ]);
 
+        if (!empty($this->filter['title'])) {
+            $query = Order::with([
+                'service',
+                'service.category',
+                'user',
+                'comments',
+                'comments.user'
+            ])->where('title','LIKE', "%{$this->filter['title']}%");
+        }
+
+
         $this->applyCategoryFilter($query);
         $this->applyServiceFilter($query);
         $this->applyLocationFilter($query);
@@ -113,7 +124,11 @@ class Orders extends Component
 
         $query->orderBy('updated_at', 'desc');
 
-        $this->orders = $query->paginate($this->paginationAmount);
+        if (!empty($this->filter['category_id']) || !empty($this->filter['service_id']) || !empty($this->filter['location_id']) || !empty($this->filter['status']) || !empty($this->filter['title'])) {
+            $this->orders = $query->paginate(1000);
+        }else{
+            $this->orders = $query->paginate($this->paginationAmount);
+        }
     }
 
     public function updatedFilter($value)

--- a/resources/views/livewire/admin/orders.blade.php
+++ b/resources/views/livewire/admin/orders.blade.php
@@ -71,6 +71,14 @@
                 <a href="#" class="label-text-alt"></a>
             </label>
         </div>
+
+        <div class="col-6">
+            <label class="label">
+                <span class="label-text">Pesquisar</span>
+                <a href="#" class="label-text-alt"></a>
+            </label>
+            <input class=" form-control input input-bordered w-full" type="text" wire:model.debounce.1000ms="filter.title">
+        </div>
     </div>
 
     <!-- list of elements -->


### PR DESCRIPTION
foi criado um filtro por meio de pesquisa na página de pedidos onde consegue procurar pelo título dos pedidos 
![image](https://user-images.githubusercontent.com/56172743/231791873-04c05b4a-a9c7-4f2f-a34a-7b26aafefa86.png)
alteração feita dentro da função findOrders() no componente Livewire de Orders, adicionada uma verificação caso exista algo na barra de pesquisa no front, esse valor é recebido pra montar a query no componente e realizar a consulta de acordo com a pesquisa. também adicionado uma verificação caso existam valores nos outros filtros dropdown para funcionar simultaneamente, mas sempre que houver filtros não há paginação para não ocorrer erros.